### PR TITLE
Show KPI variation in region drawer

### DIFF
--- a/src/components/RegionDetailDrawer.jsx
+++ b/src/components/RegionDetailDrawer.jsx
@@ -23,7 +23,7 @@ const getKpiDescriptor = (value) => {
     return { text: 'Basso', className: 'value-red' };
 };
 
-const KpiIndicator = ({ title, value, tooltipText }) => {
+const KpiIndicator = ({ title, value, variation, tooltipText }) => {
     const [isTooltipVisible, setTooltipVisible] = useState(false);
     let hideTimeout;
 
@@ -44,6 +44,22 @@ const KpiIndicator = ({ title, value, tooltipText }) => {
     const descriptor = getKpiDescriptor(value);
     const displayValue = value !== null ? value.toFixed(0) : 'N/D';
 
+    const renderVariation = () => {
+        if (variation === null || variation === undefined || isNaN(variation)) {
+            return null;
+        }
+
+        if (Math.round(variation) === 0) {
+            return <span className="kpi-variation neutral">0</span>;
+        }
+
+        const variationClass = variation > 0 ? 'positive' : 'negative';
+        const sign = variation > 0 ? '+' : '';
+        return (
+            <span className={`kpi-variation ${variationClass}`}>{sign}{variation.toFixed(0)}</span>
+        );
+    };
+
     return (
         <div className="indicator-wrapper">
             <div className="indicator-container">
@@ -61,9 +77,10 @@ const KpiIndicator = ({ title, value, tooltipText }) => {
                         </span>
                         <span className={`indicator-descriptor ${descriptor.className}`}>{descriptor.text}</span>
                     </div>
-                    <span className={`indicator-value ${style.valueClass}`}>
-                        {displayValue}
-                    </span>
+                    <div className="indicator-performance">
+                        <span className={`indicator-value ${style.valueClass}`}>{displayValue}</span>
+                        {renderVariation()}
+                    </div>
                 </div>
                 <div className="slider">
                     <div className="slider-track kpi-track"></div>
@@ -88,7 +105,7 @@ const RegionDetailDrawer = ({ regionData, onClose }) => {
 
     // regionData is expected to be the latest health data object for the region
     // e.g., { name: 'Lombardia', healthIndex: 0.8, variation: 0.05, kpis: {...} }
-    const { kpis, name } = regionData;
+    const { kpis, name, kpiVariations = {} } = regionData;
 
     return (
         <div className="drawer">
@@ -101,21 +118,25 @@ const RegionDetailDrawer = ({ regionData, onClose }) => {
                     <KpiIndicator
                         title="Affordability"
                         value={kpis.affordability}
+                        variation={kpiVariations.affordability}
                         tooltipText={KPITooltips.affordability}
                     />
                     <KpiIndicator
                         title="Demand Pressure"
                         value={kpis.demandPressure}
+                        variation={kpiVariations.demandPressure}
                         tooltipText={KPITooltips.demandPressure}
                     />
                     <KpiIndicator
                         title="Market Liquidity"
                         value={kpis.liquidity}
+                        variation={kpiVariations.liquidity}
                         tooltipText={KPITooltips.liquidity}
                     />
                     <KpiIndicator
                         title="Price Momentum"
                         value={kpis.momentum}
+                        variation={kpiVariations.momentum}
                         tooltipText={KPITooltips.momentum}
                     />
                 </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -33,15 +33,30 @@ const Home = () => {
 
   const handleRegionSelectFromList = (regionIdentifier) => {
     if (!housingData || !housingData.healthIndexData) return;
-    
+
     const regionName = normalizeRegionName(regionIdentifier.DEN_REG);
     const healthDataForRegion = housingData.healthIndexData[regionName];
 
     if (healthDataForRegion && healthDataForRegion.length > 0) {
       const latestData = healthDataForRegion[healthDataForRegion.length - 1];
+      const prevData = healthDataForRegion.length > 1 ? healthDataForRegion[healthDataForRegion.length - 2] : null;
+
+      const kpiVariations = {};
+      if (latestData.kpis && prevData && prevData.kpis) {
+        Object.keys(latestData.kpis).forEach((kpiKey) => {
+          const curr = latestData.kpis[kpiKey];
+          const prev = prevData.kpis[kpiKey];
+          kpiVariations[kpiKey] =
+            curr !== null && prev !== null && !Number.isNaN(curr) && !Number.isNaN(prev)
+              ? curr - prev
+              : null;
+        });
+      }
+
       setDrawerRegionData({
         ...latestData,
         name: regionName.charAt(0).toUpperCase() + regionName.slice(1).toLowerCase(),
+        kpiVariations,
       });
     }
   };


### PR DESCRIPTION
## Summary
- compute KPI variation when opening a region
- display the variation next to each KPI in `RegionDetailDrawer`

## Testing
- `npm run lint` *(fails: healthRange unused, React Hook rules, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68679a998350832cbe237ad032b7c6af