### PR TITLE
Show KPI variation in region drawer

### DIFF
--- a/src/components/InfoPanel.css
+++ b/src/components/InfoPanel.css
@@ -379,7 +379,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 16px;
 }
 
 .info-panel .mover-item-apple {
@@ -387,25 +387,17 @@
   justify-content: space-between;
   align-items: center;
   padding: 16px 20px;
-  border-radius: 18px;
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: var(--border-radius-lg);
+  border: 1px solid var(--glass-border);
+  border-left: 6px solid var(--accent-color, var(--color-accent-primary));
+  background-color: var(--glass-bg);
+  backdrop-filter: blur(var(--glass-blur));
   transition: all var(--transition-smooth);
-  box-shadow: 0 8px 20px rgba(0,0,0,0.25);
+  box-shadow: var(--box-shadow);
   color: #fff;
   cursor: pointer;
   position: relative;
   overflow: hidden;
-}
-
-.info-panel .mover-item-apple::after {
-  content: '';
-  position: absolute;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: linear-gradient(45deg, rgba(255,255,255,0.1), transparent);
-  z-index: 0;
 }
 
 .info-panel .mover-item-apple:hover {

--- a/src/components/InfoPanel.jsx
+++ b/src/components/InfoPanel.jsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect, useMemo } from 'react';
 import { Link } from 'react-router-dom';
 import './InfoPanel.css';
-import { loadAndParseHousingCycleData, scaleTo100 } from '../utils/dataUtils';
+import { scaleTo100 } from '../utils/dataUtils';
 import { FaSearch, FaEye, FaQuestionCircle, FaMapMarkedAlt } from 'react-icons/fa';
 
 // Funzioni helper per la colorazione dinamica dei box regione
@@ -14,27 +14,24 @@ const interpolateColor = (color1, color2, factor) => {
 };
 
 const getStyleForScore = (score) => {
-  const red = [211, 47, 47];    // Un rosso più deciso ma non troppo acceso
-  const yellow = [255, 193, 7];   // Giallo materiale
-  const green = [56, 142, 60];    // Verde più scuro e bilanciato
+  const red = [211, 47, 47];
+  const yellow = [255, 193, 7];
+  const green = [56, 142, 60];
 
   let color;
 
   if (score === null || isNaN(score)) {
-    color = 'rgb(74, 85, 104)'; // Grigio neutro per dati mancanti
+    color = 'rgb(74, 85, 104)';
   } else if (score < 50) {
-    // fattore da 0 (rosso) a 1 (giallo)
     const factor = score / 50;
     color = interpolateColor(red, yellow, factor);
   } else {
-    // fattore da 0 (giallo) a 1 (verde)
     const factor = (score - 50) / 50;
     color = interpolateColor(yellow, green, factor);
   }
-  
-  return { 
-    backgroundColor: color,
-    backgroundImage: `linear-gradient(135deg, ${color}, rgba(0,0,0,0.7))`
+
+  return {
+    '--accent-color': color,
   };
 };
 

--- a/src/components/RegionDetailDrawer.css
+++ b/src/components/RegionDetailDrawer.css
@@ -46,9 +46,13 @@
 
 .drawer-header h2 {
     margin: 0;
-    font-size: 1.75rem; /* Larger */
+    font-size: 1.75rem;
     font-weight: 700;
-    color: var(--text-primary);
+    background: linear-gradient(45deg, var(--color-primary-accent), #ffffff);
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: transparent;
+    letter-spacing: -0.5px;
+    text-shadow: 0 2px 10px rgba(30,136,229,0.3);
 }
 
 .close-btn {

--- a/src/components/RegionDetailDrawer.jsx
+++ b/src/components/RegionDetailDrawer.jsx
@@ -23,7 +23,7 @@ const getKpiDescriptor = (value) => {
     return { text: 'Basso', className: 'value-red' };
 };
 
-const KpiIndicator = ({ title, value, tooltipText }) => {
+const KpiIndicator = ({ title, value, variation, tooltipText }) => {
     const [isTooltipVisible, setTooltipVisible] = useState(false);
     let hideTimeout;
 
@@ -44,6 +44,22 @@ const KpiIndicator = ({ title, value, tooltipText }) => {
     const descriptor = getKpiDescriptor(value);
     const displayValue = value !== null ? value.toFixed(0) : 'N/D';
 
+    const renderVariation = () => {
+        if (variation === null || variation === undefined || isNaN(variation)) {
+            return null;
+        }
+
+        if (Math.round(variation) === 0) {
+            return <span className="kpi-variation neutral">0</span>;
+        }
+
+        const variationClass = variation > 0 ? 'positive' : 'negative';
+        const sign = variation > 0 ? '+' : '';
+        return (
+            <span className={`kpi-variation ${variationClass}`}>{sign}{variation.toFixed(0)}</span>
+        );
+    };
+
     return (
         <div className="indicator-wrapper">
             <div className="indicator-container">
@@ -61,9 +77,10 @@ const KpiIndicator = ({ title, value, tooltipText }) => {
                         </span>
                         <span className={`indicator-descriptor ${descriptor.className}`}>{descriptor.text}</span>
                     </div>
-                    <span className={`indicator-value ${style.valueClass}`}>
-                        {displayValue}
-                    </span>
+                    <div className="indicator-performance">
+                        <span className={`indicator-value ${style.valueClass}`}>{displayValue}</span>
+                        {renderVariation()}
+                    </div>
                 </div>
                 <div className="slider">
                     <div className="slider-track kpi-track"></div>
@@ -88,7 +105,7 @@ const RegionDetailDrawer = ({ regionData, onClose }) => {
 
     // regionData is expected to be the latest health data object for the region
     // e.g., { name: 'Lombardia', healthIndex: 0.8, variation: 0.05, kpis: {...} }
-    const { kpis, name } = regionData;
+    const { kpis, name, kpiVariations = {} } = regionData;
 
     return (
         <div className="drawer">
@@ -101,21 +118,25 @@ const RegionDetailDrawer = ({ regionData, onClose }) => {
                     <KpiIndicator
                         title="Affordability"
                         value={kpis.affordability}
+                        variation={kpiVariations.affordability}
                         tooltipText={KPITooltips.affordability}
                     />
                     <KpiIndicator
                         title="Demand Pressure"
                         value={kpis.demandPressure}
+                        variation={kpiVariations.demandPressure}
                         tooltipText={KPITooltips.demandPressure}
                     />
                     <KpiIndicator
                         title="Market Liquidity"
                         value={kpis.liquidity}
+                        variation={kpiVariations.liquidity}
                         tooltipText={KPITooltips.liquidity}
                     />
                     <KpiIndicator
                         title="Price Momentum"
                         value={kpis.momentum}
+                        variation={kpiVariations.momentum}
                         tooltipText={KPITooltips.momentum}
                     />
                 </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -33,15 +33,30 @@ const Home = () => {
 
   const handleRegionSelectFromList = (regionIdentifier) => {
     if (!housingData || !housingData.healthIndexData) return;
-    
+
     const regionName = normalizeRegionName(regionIdentifier.DEN_REG);
     const healthDataForRegion = housingData.healthIndexData[regionName];
 
     if (healthDataForRegion && healthDataForRegion.length > 0) {
       const latestData = healthDataForRegion[healthDataForRegion.length - 1];
+      const prevData = healthDataForRegion.length > 1 ? healthDataForRegion[healthDataForRegion.length - 2] : null;
+
+      const kpiVariations = {};
+      if (latestData.kpis && prevData && prevData.kpis) {
+        Object.keys(latestData.kpis).forEach((kpiKey) => {
+          const curr = latestData.kpis[kpiKey];
+          const prev = prevData.kpis[kpiKey];
+          kpiVariations[kpiKey] =
+            curr !== null && prev !== null && !Number.isNaN(curr) && !Number.isNaN(prev)
+              ? curr - prev
+              : null;
+        });
+      }
+
       setDrawerRegionData({
         ...latestData,
         name: regionName.charAt(0).toUpperCase() + regionName.slice(1).toLowerCase(),
+        kpiVariations,
       });
     }
   };


### PR DESCRIPTION
## Summary
- compute KPI variation when opening a region
- display the variation next to each KPI in `RegionDetailDrawer`
- make drawer title gradient and align top movers cards with the same look

## Testing
- `npm run lint` *(fails: react-hooks rules, unused vars, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68679a998350832cbe237ad032b7c6af